### PR TITLE
Improve dashboard visuals for a more polished UI

### DIFF
--- a/TestingFramework_V2.py
+++ b/TestingFramework_V2.py
@@ -465,8 +465,37 @@ def create_excel_with_screenshots(logs_df, writer):
                     worksheet.set_column(col_num, col_num, max_len)
 
 # Streamlit App Configuration
-st.set_page_config(layout="wide")
-st.title("Test Automation Framework")
+st.set_page_config(
+    page_title="Automation Test Dashboard",
+    page_icon="Logo.png",
+    layout="wide",
+)
+
+st.markdown(
+    """
+    <style>
+        .block-container {padding-top: 2rem;}
+        .stButton>button {
+            background-color: #4F46E5;
+            color: white;
+            border-radius: 4px;
+            border: none;
+        }
+        .stButton>button:hover {
+            background-color: #4338CA;
+            color: white;
+        }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+logo_col, title_col = st.columns([1, 5])
+with logo_col:
+    st.image("Logo.png", width=64)
+with title_col:
+    st.title("Test Automation Framework")
+    st.caption("Create, schedule, and run automated tests with ease.")
 
 # Initialize session state
 if "steps" not in st.session_state:

--- a/dashboard
+++ b/dashboard
@@ -19,7 +19,8 @@ Use below html tag for RTL version
     />
     <link rel="stylesheet" href="/fonticon/fonticon.css" />
     <link rel="stylesheet" href="/splash-screen.css" />
-    <title>Novellus CRM</title>
+    <title>Automated Test Dashboard</title>
+    <meta name="description" content="Automation test dashboard for creating and running automated tests." />
     <script type="module" crossorigin src="/assets/index-VKdgZKVD.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-E9YWGemU.css">
   </head>
@@ -58,8 +59,8 @@ Use below html tag for RTL version
     <!-- built files will be auto injected -->
     <!--begin::Loading markup-->
     <div id="splash-screen" class="splash-screen">
-      <img src="/media/logos/novellus-signup.svg" alt="Metronic logo" />
-      <span>Loading ...</span>
+      <img src="/Logo.png" alt="Automation logo" />
+      <span>Loading Test Dashboard...</span>
     </div>
     <!--end::Loading markup-->
   </body>


### PR DESCRIPTION
## Summary
- Add page title, icon, and custom styling to Streamlit dashboard
- Display logo with tagline for clearer branding
- Update static dashboard HTML with new title, description, and splash screen

## Testing
- `python -m py_compile TestingFramework_V2.py`


------
https://chatgpt.com/codex/tasks/task_e_6894a5d3b32c83209bfa7cc9526d3692