### PR TITLE
Use taupe background for dashboard

### DIFF
--- a/TestingFramework_V2.py
+++ b/TestingFramework_V2.py
@@ -651,6 +651,9 @@ st.markdown(
     """
     <style>
         .block-container {padding-top: 2rem;}
+        body {
+            background-color: #AD965F;
+        }
         .stButton>button {
             background-color: #4F46E5;
             color: white;

--- a/splash-screen.css
+++ b/splash-screen.css
@@ -1,0 +1,3 @@
+body, .splash-screen {
+  background-color: #AD965F;
+}


### PR DESCRIPTION
## Summary
- Add CSS file that sets background color to #AD965F
- Apply the same #AD965F background in the Streamlit app

## Testing
- `pytest`
- `python -m py_compile TestingFramework_V2.py`


------
https://chatgpt.com/codex/tasks/task_e_6895331428648320b91bdecc2d7f8ffb